### PR TITLE
fix: #16 define property before construct call

### DIFF
--- a/src/package/polyfill/constructInstance.ts
+++ b/src/package/polyfill/constructInstance.ts
@@ -11,7 +11,7 @@ export function constructInstance(mostRecentImpl: any, args: any, newTarget: any
     // This patch loop makes sure that the hook methods aren't overridden,
     // the constructor stays intact but methods, getters, setters and fields
     // are updated according to the most recent implementation:
-    const customElementInstance = Reflect.construct(mostRecentImpl, args, newTarget);
+
     const ownPropertyNames = Object.getOwnPropertyNames(mostRecentImpl.prototype);
 
     const whitelistedPropertyNames = ownPropertyNames.filter((propertyName: string) => {
@@ -26,11 +26,14 @@ export function constructInstance(mostRecentImpl: any, args: any, newTarget: any
 
         if (propertyDescriptor) {
             Object.defineProperty(
-                customElementInstance,
+                newTarget.prototype,
                 whitelistedPropertyNames[i],
                 propertyDescriptor
             );
         }
     }
+
+    const customElementInstance = Reflect.construct(mostRecentImpl, args, newTarget);
+
     return customElementInstance;
 }

--- a/src/package/polyfill/constructInstance.ts
+++ b/src/package/polyfill/constructInstance.ts
@@ -25,11 +25,18 @@ export function constructInstance(mostRecentImpl: any, args: any, newTarget: any
         );
 
         if (propertyDescriptor) {
-            Object.defineProperty(
-                newTarget.prototype,
-                whitelistedPropertyNames[i],
-                propertyDescriptor
-            );
+            if (propertyDescriptor.configurable) {
+                Object.defineProperty(
+                    newTarget.prototype,
+                    whitelistedPropertyNames[i],
+                    propertyDescriptor
+                );
+            } else {
+                console.warn(
+                    '[custom-element-hmr-polyfill]',
+                    `${whitelistedPropertyNames[i]} is not configurable, skipping`
+                );
+            }
         }
     }
 

--- a/src/package/polyfill/createHookClass.ts
+++ b/src/package/polyfill/createHookClass.ts
@@ -36,13 +36,15 @@ export function createHookClass(elementName: string, originalImpl: any) {
             };
 
             // call initial callback when class is created
-            attributes.forEach(attributeName => {
-                mostRecentImpl.attributeChangedCallback.apply(this, [
-                    attributeName,
-                    null,
-                    this.getAttribute(attributeName)
-                ]);
-            });
+            if (attributes) {
+                attributes.forEach(attributeName => {
+                    mostRecentImpl.attributeChangedCallback.apply(this, [
+                        attributeName,
+                        null,
+                        this.getAttribute(attributeName)
+                    ]);
+                });
+            }
 
             // create and observe
             (<any>this)[getSymbolObserver(elementName)] = new MutationObserver(callback);


### PR DESCRIPTION
@kyr0 

Started look at this.
Looks like we can just define the properties before the constructor call
Added sample code under to test it wihout to much work, just trigger save
We also need to add the tests we have been planning :-)
I need to do some other work atm, but will look at the other issues after

```ts
import { applyPolyfill, ReflowStrategy } from 'custom-elements-hmr-polyfill';

applyPolyfill(ReflowStrategy.REPLACE_BY_CLONE, 150 /* ms */, (elementName: string) => {
    console.log('[Web Component code change] ', elementName);
});

if ((<any>window).y) {
    (<any>window).y = 0;
    console.log(`Running FOO---------------------`);
    class MyElement extends HTMLElement {
        constructor() {
            super();
            console.log(this.getFoo());
        }

        connectedCallback() {
            this.innerHTML = 'Hello world';
        }

        getFoo() {
            return 'foo';
        }
    }

    customElements.define('app-root', MyElement);
} else {
    console.log(`Running Simple---------------------`);
    (<any>window).y = 1;
    class MyElement extends HTMLElement {
        constructor() {
            super();
        }

        connectedCallback() {
            this.innerHTML = 'Hello world';
        }
    }

    customElements.define('app-root', MyElement);
}
```